### PR TITLE
Use Empty Functions

### DIFF
--- a/dist/collapsible.js
+++ b/dist/collapsible.js
@@ -62,8 +62,8 @@ var Collapsible = React.createClass({displayName: 'Collapsible',
   getDefaultProps: function () {
     return {
       open: false,
-      onOpen: null,
-      onClose: null
+      onOpen: function () {},
+      onClose: function () {}
     }
   },
 
@@ -111,9 +111,7 @@ var Collapsible = React.createClass({displayName: 'Collapsible',
       return; /* nothing to do */
     }
 
-    if (this.props.onOpen) {
-      this.props.onOpen(this);
-    }
+    this.props.onOpen(this);
 
     this.setState({
       open: true
@@ -125,9 +123,7 @@ var Collapsible = React.createClass({displayName: 'Collapsible',
       return; /* nothing to do */
     }
 
-    if (this.props.onClose) {
-      this.props.onClose(this);
-    }
+    this.props.onClose(this);
 
     this.setState({
       open: false

--- a/example/collapsible.js
+++ b/example/collapsible.js
@@ -62,8 +62,8 @@ var Collapsible = React.createClass({displayName: 'Collapsible',
   getDefaultProps: function () {
     return {
       open: false,
-      onOpen: null,
-      onClose: null
+      onOpen: function () {},
+      onClose: function () {}
     }
   },
 
@@ -111,9 +111,7 @@ var Collapsible = React.createClass({displayName: 'Collapsible',
       return; /* nothing to do */
     }
 
-    if (this.props.onOpen) {
-      this.props.onOpen(this);
-    }
+    this.props.onOpen(this);
 
     this.setState({
       open: true
@@ -125,9 +123,7 @@ var Collapsible = React.createClass({displayName: 'Collapsible',
       return; /* nothing to do */
     }
 
-    if (this.props.onClose) {
-      this.props.onClose(this);
-    }
+    this.props.onClose(this);
 
     this.setState({
       open: false

--- a/src/jsx/Collapsible.jsx
+++ b/src/jsx/Collapsible.jsx
@@ -11,8 +11,8 @@ var Collapsible = React.createClass({
   getDefaultProps: function () {
     return {
       open: false,
-      onOpen: null,
-      onClose: null
+      onOpen: function () {},
+      onClose: function () {}
     }
   },
 
@@ -60,9 +60,7 @@ var Collapsible = React.createClass({
       return; /* nothing to do */
     }
 
-    if (this.props.onOpen) {
-      this.props.onOpen(this);
-    }
+    this.props.onOpen(this);
 
     this.setState({
       open: true
@@ -74,9 +72,7 @@ var Collapsible = React.createClass({
       return; /* nothing to do */
     }
 
-    if (this.props.onClose) {
-      this.props.onClose(this);
-    }
+    this.props.onClose(this);
 
     this.setState({
       open: false


### PR DESCRIPTION
In Collapsible, use empty functions instead of null for default props.
